### PR TITLE
Changed default ssg base path to /usr/share/xml/scap/ssg/content

### DIFF
--- a/manifests/schedule.pp
+++ b/manifests/schedule.pp
@@ -33,7 +33,7 @@
 #
 # [*ssg_base_dir*]
 #   Type: Absolute Path
-#   Default: "/usr/share/xml/scap/ssg/rhel${::operatingsystemmajrelease}"
+#   Default: "/usr/share/xml/scap/ssg/content"
 #
 #   The starting directory for all SSG content. Change this if you want to
 #   install your own SSG profiles.
@@ -77,7 +77,7 @@
 class openscap::schedule (
   $scap_profile = "xccdf_org.ssgproject.content_profile_stig-rhel${::operatingsystemmajrelease}-server-upstream",
   $scap_tailoring_file = false,
-  $ssg_base_dir = "/usr/share/xml/scap/ssg/rhel${::operatingsystemmajrelease}",
+  $ssg_base_dir = "/usr/share/xml/scap/ssg/content",
   $ssg_data_stream = "ssg-rhel${::operatingsystemmajrelease}-ds.xml",
   $fetch_remote_resources = false,
   $logdir = '/var/log/openscap',


### PR DESCRIPTION
This path is used on RHEL6, RHEL7, Fedora and others.

The previous path is old, it was used in the past but we transitioned to this new path and we pledge to support it in the future.