### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,8 @@ fixtures:
   repositories:
     auditd: "git://github.com/simp/pupmod-simp-auditd"
     common: "git://github.com/simp/pupmod-simp-common"
-    concat: "git://github.com/simp/pupmod-simp-concat"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
+    simpcat: "git://github.com/simp/pupmod-simp-concat"
     logrotate: "git://github.com/simp/pupmod-simp-logrotate"
     rsyslog: "git://github.com/simp/pupmod-simp-rsyslog"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"

--- a/build/pupmod-openscap.spec
+++ b/build/pupmod-openscap.spec
@@ -1,12 +1,13 @@
 Summary: OPENSCAP Puppet Module
 Name: pupmod-openscap
 Version: 4.2.0
-Release: 2
+Release: 3
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-common >= 4.2.0-0
+Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-logrotate
 Requires: pupmod-rsyslog >= 4.1.0-1
 Requires: puppet >= 3.3.0
@@ -50,6 +51,9 @@ mkdir -p %{buildroot}/%{prefix}/openscap
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.2.0-3
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Feb 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-2
 - Updated to use the new 'simp' environment.
 - Changed calls directly to /etc/init.d/rsyslog to '/sbin/service rsyslog' so


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-openscap`.
SIMP-604 #comment Updated `pupmod-simp-openscap`.