### PR TITLE
Update to openscap variables to fix issue with new/updated profile names

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,117 @@
-#
 ---
-puppet-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    key: "$CI_BUILD_REF_NAME"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_bundler_env: &setup_bundler_env
+  before_script:
+    - gem install bundler
+    - rm -f Gemfile.lock
+    - bundle install --no-binstubs --path .vendor "${FLAGS[@]}"
+
+.syntax_checks: &syntax_checks
+  script:
     - bundle exec rake syntax
-puppet-lint: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake lint
-puppet-metadata: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake compare_latest_tag
+
+.spec_tests: &spec_tests
+  script:
     - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags: 
+
+stages:
+  - syntax
+  - unit
+  - acceptance
+  - deploy
+
+puppet-syntax:
+  stage: syntax
+  tags:
     - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags: 
+  image: ruby:2.4
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
+
+# Puppet 4
+unit-ruby-2.1.9:
+  stage: unit
+  tags:
     - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
+  image: ruby:2.1.9
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+# Puppet 5
+unit-ruby-2.4.1:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
-  stage: test
-  tags: 
+puppet4.7-syntax:
+  stage: syntax
+  tags:
     - docker
   image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
+  variables:
+    PUPPET_VERSION: '4.7'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
 
-acceptance-test: 
-  stage: test
-  tags: 
+unit-puppet4.7-ruby-2.1:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '4.7'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+
+puppet5-syntax:
+  stage: syntax
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *syntax_checks
+
+unit-puppet5-ruby-2.4:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '5.0'
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  <<: *spec_tests
+  allow_failure: true
+
+acceptance-default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+  <<: *cache_bundler
+  <<: *setup_bundler_env
+  script:
+    - bundle exec rake beaker:suites[default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,46 +10,58 @@
 language: ruby
 sudo: false
 cache: bundler
-before_script:
-  - bundle update
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "G6S8XPjTlqWHMhWtIGPXK0z294Y6kgdUi5G8ySWSCgj4hLuH9gCGgE6zzZTRAycFt08bux9AvIw65VEqDM1MVYYPJKI0PDr3o9/47mLZBVSwJfae2DBekTqb5/pH/WGdzc7olpQs/G+qpT5FKg4L1rVFnhPjcb2IEChU5lhNgY2I+mei4RXIk92o3X53c9MORyaHIaHW09QG0JXB+G4tmDQK8tX6hQoDbqEPKq8q7irSCHqm5o/ICAB35QAv6XaQU+WQ13rUbDKkrYkWtHb3zWFikBOj7AHHxEUFYjh8YZIpVaVNni9JH4rKVCx3igTdZvT3seEf97gniZ2mwCO0gc4E/RkDqR0nK/EzPhC1yAyWN+hlugc1B+XBxQOpfXIv6xelZwQww7aGCn/6g7RWFsTdp89Idp/X+hyH/NboDjBfaySJ0bR3IcXzkMxIzqQF1mxk9zyMgN4SkrK+Lf6Bh1EZPTkM5pjqSnFZhyVwJKzpf0++NNL9w/v4FU5BnJjqOmBhxJk0yukIY3y3RDKJKxAHh5hXFJ0bC31nBc3X0vchQmLqeZ9NjiZvwZBLCcdVMrAHTvW6KYAilBOxXMbywSV5i+7qdxniMe+Yuyf30pqQMdpUGcDtz3QJgO4DFeCdXWfDCU8vtPv/Lg+U7u5TsiljW/hBQ1rXHXo+dp7EpB0="
-    on:
-      tags: true
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  fast_finish: true
+  allow_failures:
+    - env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+
+  include:
+    - stage: test
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "HRo82jcdj+UhrZUfHo/tIo2nNajUo4VQAMiKLzo2pmVidK2t6XkEqfbkFu47yHMPdlIGl9cFOmoPWwvKSXH7nZoGnMZi2LZiG1fkkgbnlrhholKLfX1LVhJiuF0Zb8Kk8y2herq5lWB1hRCY8hFVe7JPcwpnOI+xU3O/7PiPImMGZH4LAR4Rww7rIMLZGz8sjWy5N07qYasHngiuv/TdxNrJHAwLQI+EV5V/aG9xx9iP9eZPk6tUYvFWwJcaiEMNnW1yJ4m55wjLSCGI7lGGw62ThB5o2bYP4ndnVf81iaKlcpy+id+5cDjRKjV/lyk5cSNnS8JwCLbmpX5kLU29s2/IgIlGvp6rljdZ+X+WimbLv9AGl+2TmhHe0qxPioFIUD2iMtDDFt3rYCXV5dLEgLD8zW4r9vCJUL7Mz8HfInCELibGh4KMaalgTKcJRjfqxt7AJ3by934i+n3c31exXGjxsk6Vh46nt4BDMV4zebUsFcrBt9MsHh54+KMA+o9/Dy2+UQ3fNtm3cGBixoeZhosGX8HKKEMX51uSl88wG7gsllE7F07o+a/eibOX1PNKAnuspk1JEJELZuu2McC7/7unuA0KQ/2l5FLpywMcdoSRdHNXknfYCFOmdzRoa5jqPAx4e4Ijx3/Jde69KODtumiT4eOFlxoiccusJUscyYw="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: PUPPET_VERSION="~> 4.10.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+      script:
+        - bundle exec rake test
+
+    - stage: test
+      rvm: 2.1.9
+      env: PUPPET_VERSION="~> 4.7.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+      script:
+        - bundle exec rake test
+
+    - stage: test
+      rvm: 2.1.9
+      env: PUPPET_VERSION="~> 4.8.2" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+      script:
+        - bundle exec rake compare_latest_tag
+        - bundle exec rake test
+      before_deploy:
+        - 'bundle exec rake metadata_lint'
+        - 'bundle exec rake clobber'
+        - 'bundle exec rake spec_clean'
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: puppetforge
+          user: simp
+          password:
+              secure: "G6S8XPjTlqWHMhWtIGPXK0z294Y6kgdUi5G8ySWSCgj4hLuH9gCGgE6zzZTRAycFt08bux9AvIw65VEqDM1MVYYPJKI0PDr3o9/47mLZBVSwJfae2DBekTqb5/pH/WGdzc7olpQs/G+qpT5FKg4L1rVFnhPjcb2IEChU5lhNgY2I+mei4RXIk92o3X53c9MORyaHIaHW09QG0JXB+G4tmDQK8tX6hQoDbqEPKq8q7irSCHqm5o/ICAB35QAv6XaQU+WQ13rUbDKkrYkWtHb3zWFikBOj7AHHxEUFYjh8YZIpVaVNni9JH4rKVCx3igTdZvT3seEf97gniZ2mwCO0gc4E/RkDqR0nK/EzPhC1yAyWN+hlugc1B+XBxQOpfXIv6xelZwQww7aGCn/6g7RWFsTdp89Idp/X+hyH/NboDjBfaySJ0bR3IcXzkMxIzqQF1mxk9zyMgN4SkrK+Lf6Bh1EZPTkM5pjqSnFZhyVwJKzpf0++NNL9w/v4FU5BnJjqOmBhxJk0yukIY3y3RDKJKxAHh5hXFJ0bC31nBc3X0vchQmLqeZ9NjiZvwZBLCcdVMrAHTvW6KYAilBOxXMbywSV5i+7qdxniMe+Yuyf30pqQMdpUGcDtz3QJgO4DFeCdXWfDCU8vtPv/Lg+U7u5TsiljW/hBQ1rXHXo+dp7EpB0="
+          on:
+            tags: true
+            rvm: 2.1.9
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: releases
+          api_key:
+              secure: "HRo82jcdj+UhrZUfHo/tIo2nNajUo4VQAMiKLzo2pmVidK2t6XkEqfbkFu47yHMPdlIGl9cFOmoPWwvKSXH7nZoGnMZi2LZiG1fkkgbnlrhholKLfX1LVhJiuF0Zb8Kk8y2herq5lWB1hRCY8hFVe7JPcwpnOI+xU3O/7PiPImMGZH4LAR4Rww7rIMLZGz8sjWy5N07qYasHngiuv/TdxNrJHAwLQI+EV5V/aG9xx9iP9eZPk6tUYvFWwJcaiEMNnW1yJ4m55wjLSCGI7lGGw62ThB5o2bYP4ndnVf81iaKlcpy+id+5cDjRKjV/lyk5cSNnS8JwCLbmpX5kLU29s2/IgIlGvp6rljdZ+X+WimbLv9AGl+2TmhHe0qxPioFIUD2iMtDDFt3rYCXV5dLEgLD8zW4r9vCJUL7Mz8HfInCELibGh4KMaalgTKcJRjfqxt7AJ3by934i+n3c31exXGjxsk6Vh46nt4BDMV4zebUsFcrBt9MsHh54+KMA+o9/Dy2+UQ3fNtm3cGBixoeZhosGX8HKKEMX51uSl88wG7gsllE7F07o+a/eibOX1PNKAnuspk1JEJELZuu2McC7/7unuA0KQ/2l5FLpywMcdoSRdHNXknfYCFOmdzRoa5jqPAx4e4Ijx3/Jde69KODtumiT4eOFlxoiccusJUscyYw="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,60 +8,87 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
+sudo: false
 
 bundler_args: --without development system_tests --path .vendor
 
 notifications:
   email: false
 
+addons:
+  apt:
+    packages:
+      - rpm
+
 before_install:
   - rm -f Gemfile.lock
 
 jobs:
-  fast_finish: true
   allow_failures:
-    - env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
 
   include:
-    - stage: test
+    - stage: check
       rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
       script:
-        - bundle exec rake test
-
-    - stage: test
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.7.0" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
-      script:
-        - bundle exec rake test
-
-    - stage: test
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.8.2" STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes
-      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
         - bundle exec rake compare_latest_tag
-        - bundle exec rake test
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    # This needs to be last since we have an acceptance test
+    - stage: deploy
+      rvm: 2.1.9
+      script:
+        - true
       before_deploy:
-        - 'bundle exec rake metadata_lint'
-        - 'bundle exec rake clobber'
-        - 'bundle exec rake spec_clean'
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
         - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
       deploy:
-        - provider: puppetforge
-          user: simp
-          password:
-              secure: "G6S8XPjTlqWHMhWtIGPXK0z294Y6kgdUi5G8ySWSCgj4hLuH9gCGgE6zzZTRAycFt08bux9AvIw65VEqDM1MVYYPJKI0PDr3o9/47mLZBVSwJfae2DBekTqb5/pH/WGdzc7olpQs/G+qpT5FKg4L1rVFnhPjcb2IEChU5lhNgY2I+mei4RXIk92o3X53c9MORyaHIaHW09QG0JXB+G4tmDQK8tX6hQoDbqEPKq8q7irSCHqm5o/ICAB35QAv6XaQU+WQ13rUbDKkrYkWtHb3zWFikBOj7AHHxEUFYjh8YZIpVaVNni9JH4rKVCx3igTdZvT3seEf97gniZ2mwCO0gc4E/RkDqR0nK/EzPhC1yAyWN+hlugc1B+XBxQOpfXIv6xelZwQww7aGCn/6g7RWFsTdp89Idp/X+hyH/NboDjBfaySJ0bR3IcXzkMxIzqQF1mxk9zyMgN4SkrK+Lf6Bh1EZPTkM5pjqSnFZhyVwJKzpf0++NNL9w/v4FU5BnJjqOmBhxJk0yukIY3y3RDKJKxAHh5hXFJ0bC31nBc3X0vchQmLqeZ9NjiZvwZBLCcdVMrAHTvW6KYAilBOxXMbywSV5i+7qdxniMe+Yuyf30pqQMdpUGcDtz3QJgO4DFeCdXWfDCU8vtPv/Lg+U7u5TsiljW/hBQ1rXHXo+dp7EpB0="
-          on:
-            tags: true
-            rvm: 2.1.9
-            condition: '($SKIP_FORGE_PUBLISH != true)'
         - provider: releases
           api_key:
-              secure: "HRo82jcdj+UhrZUfHo/tIo2nNajUo4VQAMiKLzo2pmVidK2t6XkEqfbkFu47yHMPdlIGl9cFOmoPWwvKSXH7nZoGnMZi2LZiG1fkkgbnlrhholKLfX1LVhJiuF0Zb8Kk8y2herq5lWB1hRCY8hFVe7JPcwpnOI+xU3O/7PiPImMGZH4LAR4Rww7rIMLZGz8sjWy5N07qYasHngiuv/TdxNrJHAwLQI+EV5V/aG9xx9iP9eZPk6tUYvFWwJcaiEMNnW1yJ4m55wjLSCGI7lGGw62ThB5o2bYP4ndnVf81iaKlcpy+id+5cDjRKjV/lyk5cSNnS8JwCLbmpX5kLU29s2/IgIlGvp6rljdZ+X+WimbLv9AGl+2TmhHe0qxPioFIUD2iMtDDFt3rYCXV5dLEgLD8zW4r9vCJUL7Mz8HfInCELibGh4KMaalgTKcJRjfqxt7AJ3by934i+n3c31exXGjxsk6Vh46nt4BDMV4zebUsFcrBt9MsHh54+KMA+o9/Dy2+UQ3fNtm3cGBixoeZhosGX8HKKEMX51uSl88wG7gsllE7F07o+a/eibOX1PNKAnuspk1JEJELZuu2McC7/7unuA0KQ/2l5FLpywMcdoSRdHNXknfYCFOmdzRoa5jqPAx4e4Ijx3/Jde69KODtumiT4eOFlxoiccusJUscyYw="
+            secure: "HRo82jcdj+UhrZUfHo/tIo2nNajUo4VQAMiKLzo2pmVidK2t6XkEqfbkFu47yHMPdlIGl9cFOmoPWwvKSXH7nZoGnMZi2LZiG1fkkgbnlrhholKLfX1LVhJiuF0Zb8Kk8y2herq5lWB1hRCY8hFVe7JPcwpnOI+xU3O/7PiPImMGZH4LAR4Rww7rIMLZGz8sjWy5N07qYasHngiuv/TdxNrJHAwLQI+EV5V/aG9xx9iP9eZPk6tUYvFWwJcaiEMNnW1yJ4m55wjLSCGI7lGGw62ThB5o2bYP4ndnVf81iaKlcpy+id+5cDjRKjV/lyk5cSNnS8JwCLbmpX5kLU29s2/IgIlGvp6rljdZ+X+WimbLv9AGl+2TmhHe0qxPioFIUD2iMtDDFt3rYCXV5dLEgLD8zW4r9vCJUL7Mz8HfInCELibGh4KMaalgTKcJRjfqxt7AJ3by934i+n3c31exXGjxsk6Vh46nt4BDMV4zebUsFcrBt9MsHh54+KMA+o9/Dy2+UQ3fNtm3cGBixoeZhosGX8HKKEMX51uSl88wG7gsllE7F07o+a/eibOX1PNKAnuspk1JEJELZuu2McC7/7unuA0KQ/2l5FLpywMcdoSRdHNXknfYCFOmdzRoa5jqPAx4e4Ijx3/Jde69KODtumiT4eOFlxoiccusJUscyYw="
           skip_cleanup: true
           on:
             tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "G6S8XPjTlqWHMhWtIGPXK0z294Y6kgdUi5G8ySWSCgj4hLuH9gCGgE6zzZTRAycFt08bux9AvIw65VEqDM1MVYYPJKI0PDr3o9/47mLZBVSwJfae2DBekTqb5/pH/WGdzc7olpQs/G+qpT5FKg4L1rVFnhPjcb2IEChU5lhNgY2I+mei4RXIk92o3X53c9MORyaHIaHW09QG0JXB+G4tmDQK8tX6hQoDbqEPKq8q7irSCHqm5o/ICAB35QAv6XaQU+WQ13rUbDKkrYkWtHb3zWFikBOj7AHHxEUFYjh8YZIpVaVNni9JH4rKVCx3igTdZvT3seEf97gniZ2mwCO0gc4E/RkDqR0nK/EzPhC1yAyWN+hlugc1B+XBxQOpfXIv6xelZwQww7aGCn/6g7RWFsTdp89Idp/X+hyH/NboDjBfaySJ0bR3IcXzkMxIzqQF1mxk9zyMgN4SkrK+Lf6Bh1EZPTkM5pjqSnFZhyVwJKzpf0++NNL9w/v4FU5BnJjqOmBhxJk0yukIY3y3RDKJKxAHh5hXFJ0bC31nBc3X0vchQmLqeZ9NjiZvwZBLCcdVMrAHTvW6KYAilBOxXMbywSV5i+7qdxniMe+Yuyf30pqQMdpUGcDtz3QJgO4DFeCdXWfDCU8vtPv/Lg+U7u5TsiljW/hBQ1rXHXo+dp7EpB0="
+          on:
+            tags: true
+            rvm: 2.1.9
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Nov 28 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.3
+-Changed Openscap::Profile type to use regex match on profiles rather than the Enum.
+-Added hieradata to module to specify scap_profile and ssg_data_stream based on OS (RedHat 6, RedHat 7, CentOS 6, and CentOS 7)
+
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.2-0
 - Updated logrotate to use new lastaction API
 - Confine puppet version in metadata.json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Wed Nov 28 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.3
--Changed Openscap::Profile type to use regex match on profiles rather than the Enum.
--Added hieradata to module to specify scap_profile and ssg_data_stream based on OS (RedHat 6, RedHat 7, CentOS 6, and CentOS 7)
+- Changed Openscap::Profile type to use regex match on profiles rather than the Enum.
+- Added hieradata to module to specify scap_profile and ssg_data_stream based
+  on OS (RedHat 6, RedHat 7, CentOS 6, and CentOS 7)
 
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.2-0
 - Updated logrotate to use new lastaction API

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 4.0', '< 6.0'])
 end
 
 group :development do
@@ -27,6 +27,7 @@ group :development do
   gem 'puppet-blacksmith'
   gem 'guard-rake'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'pry-doc'
 
   # `listen` is a dependency of `guard`

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,7 +1,0 @@
-Obsoletes: pupmod-openscap-test >= 0.0.1
-Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
-Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0
-Requires: pupmod-simp-logrotate < 7.0.0-0
-Requires: pupmod-simp-logrotate >= 6.1.0-0
-Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0

--- a/data/os/CentOS-6.yaml
+++ b/data/os/CentOS-6.yaml
@@ -1,0 +1,3 @@
+---
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-disa"
+openscap::schedule::ssg_data_stream: "ssg-centos6-ds.xml"

--- a/data/os/CentOS-7.yaml
+++ b/data/os/CentOS-7.yaml
@@ -1,0 +1,3 @@
+---
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+openscap::schedule::ssg_data_stream: "ssg-centos7-ds.xml"

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -1,0 +1,3 @@
+---
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-disa"
+openscap::schedule::ssg_data_stream: "ssg-rhel6-ds.xml"

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,0 +1,3 @@
+---
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+openscap::schedule::ssg_data_stream: "ssg-rhel7-ds.xml"

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,6 +5,5 @@ hierarchy:
   - name: "OS Major Release"
     backend: yaml
     path: "os/%{facts.os.name}-%{facts.os.release.major}"
-
   - name: "common"
     backend: yaml

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "OS Major Release"
+    backend: yaml
+    path: "os/%{facts.os.name}-%{facts.os.release.major}"
+
+  - name: "common"
+    backend: yaml

--- a/manifests/schedule.pp
+++ b/manifests/schedule.pp
@@ -50,9 +50,9 @@
 # @author Kendall Moore <kmoore@keywcorp.com>
 #
 class openscap::schedule (
-  Openscap::Profile                $scap_profile           = "xccdf_org.ssgproject.content_profile_stig-rhel${::operatingsystemmajrelease}-server-upstream",
+  Openscap::Profile                $scap_profile,
+  Pattern[/^.+\.xml$/]             $ssg_data_stream,
   Stdlib::Absolutepath             $ssg_base_dir           = '/usr/share/xml/scap/ssg/content',
-  Pattern[/^.+\.xml$/]             $ssg_data_stream        = "ssg-rhel${::operatingsystemmajrelease}-ds.xml",
   Boolean                          $fetch_remote_resources = false,
   Stdlib::Absolutepath             $logdir                 = '/var/log/openscap',
   Boolean                          $logrotate              = simplib::lookup('simp_options::logrotate', { 'default_value' => false}),

--- a/metadata.json
+++ b/metadata.json
@@ -47,5 +47,6 @@
       "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ]
+},
   "data_provider": "hiera"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,6 @@
       "name": "puppet",
       "version_requirement": ">= 4.7.0 < 5.0.0"
     }
-  ]
-},
+  ],
   "data_provider": "hiera"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-openscap",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "SIMP Team",
   "summary": "Safely manages openscap",
   "license": "Apache-2.0",
@@ -47,4 +47,5 @@
       "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ]
+  "data_provider": "hiera"
 }

--- a/spec/type_aliases/openscap_profile_spec.rb
+++ b/spec/type_aliases/openscap_profile_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'Openscap::Profile' do
+  
+  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rh    el7-disa') }
+  
+  it { is_expected.not_to allow_values('test_profile_rhel', 'xccdf_org.test_profile') }
+
+end

--- a/spec/type_aliases/openscap_profile_spec.rb
+++ b/spec/type_aliases/openscap_profile_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'Openscap::Profile' do
-  
-  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rh    el7-disa') }
-  
+
+  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rhel7-disa') }
+
   it { is_expected.not_to allow_values('test_profile_rhel', 'xccdf_org.test_profile') }
 
 end

--- a/types/profile.pp
+++ b/types/profile.pp
@@ -1,15 +1,1 @@
-type Openscap::Profile = Enum[
-  'xccdf_org.ssgproject.content_profile_test',
-  'xccdf_org.ssgproject.content_profile_CS2',
-  'xccdf_org.ssgproject.content_profile_common',
-  'xccdf_org.ssgproject.content_profile_server',
-  'xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream',
-  'xccdf_org.ssgproject.content_profile_usgcb-rhel6-server',
-  'xccdf_org.ssgproject.content_profile_rht-ccp',
-  'xccdf_org.ssgproject.content_profile_CSCF-RHEL6-MLS',
-  'xccdf_org.ssgproject.content_profile_C2S',
-  'xccdf_org.ssgproject.content_profile_test',
-  'xccdf_org.ssgproject.content_profile_rht-ccp',
-  'xccdf_org.ssgproject.content_profile_common',
-  'xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream'
-]
+type Openscap::Profile = Pattern[/xccdf_[^_]+_profile_.+/]


### PR DESCRIPTION
-Changed Openscap::Profile type to use regex match on profiles rather than the Enum.
-Added hieradata to module to specify scap_profile and ssg_data_stream based on OS (RedHat 6, RedHat 7, CentOS 6, and CentOS 7)