### PR TITLE
Update default scap_profile

### DIFF
--- a/data/os/CentOS-6.yaml
+++ b/data/os/CentOS-6.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-centos6-ds.xml"

--- a/data/os/CentOS-7.yaml
+++ b/data/os/CentOS-7.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-centos7-ds.xml"

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-rhel6-ds.xml"

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-rhel7-ds.xml"

--- a/spec/type_aliases/openscap_profile_spec.rb
+++ b/spec/type_aliases/openscap_profile_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Openscap::Profile' do
 
-  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rhel7-disa') }
+  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream') }
 
   it { is_expected.not_to allow_values('test_profile_rhel', 'xccdf_org.test_profile') }
 


### PR DESCRIPTION
The current default scap_profile setting of rhel{6,7}-disa is invalid as
a base profile for the standard data stream file.

This updates the code to use rhel{6,7}-server-upstream as the default
scap_profile so that data does not have to be overridden in hiera for an
error not to occur.