### PR TITLE
(SIMP-4384) Update default scap_profile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Feb 01 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.0.4
+- Updated openscap::schedule::scap_profile settings in module hieradata based
+  on current *-disa settings being invalid in default installation
+
 * Wed Nov 28 2017 Brandon Riden <brandon.riden@onyxpoint.com> - 6.0.3
 - Changed Openscap::Profile type to use regex match on profiles rather than the Enum.
 - Added hieradata to module to specify scap_profile and ssg_data_stream based

--- a/data/os/CentOS-6.yaml
+++ b/data/os/CentOS-6.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-centos6-ds.xml"

--- a/data/os/CentOS-7.yaml
+++ b/data/os/CentOS-7.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-centos7-ds.xml"

--- a/data/os/RedHat-6.yaml
+++ b/data/os/RedHat-6.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel6-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-rhel6-ds.xml"

--- a/data/os/RedHat-7.yaml
+++ b/data/os/RedHat-7.yaml
@@ -1,3 +1,3 @@
 ---
-openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-disa"
+openscap::schedule::scap_profile: "xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream"
 openscap::schedule::ssg_data_stream: "ssg-rhel7-ds.xml"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-openscap",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "Safely manages openscap",
   "license": "Apache-2.0",

--- a/spec/type_aliases/openscap_profile_spec.rb
+++ b/spec/type_aliases/openscap_profile_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Openscap::Profile' do
 
-  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rhel7-disa') }
+  it { is_expected.to allow_values('xccdf_org.ssgproject.content_profile_rht-ccp', 'xccdf_org.ssgproject.content_profile_stig-rhel7-server-upstream') }
 
   it { is_expected.not_to allow_values('test_profile_rhel', 'xccdf_org.test_profile') }
 


### PR DESCRIPTION
The current default scap_profile setting of rhel{6,7}-disa is invalid as
a base profile for the standard data stream file.

This updates the code to use rhel{6,7}-server-upstream as the default
scap_profile so that data does not have to be overridden in hiera for an
error not to occur.

SIMP-4384 #close